### PR TITLE
Upgrade to Postgres 17 image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG base=docker.io/library/postgres:17-bookworm
 FROM $base
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-15-debversion && \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-17-debversion && \
     echo 'CREATE EXTENSION debversion' > /docker-entrypoint-initdb.d/create-extension.sql
 
 ADD postgresql.conf /etc/postgresql/

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG base=docker.io/library/postgres:15-bookworm
+ARG base=docker.io/library/postgres:17-bookworm
 FROM $base
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-15-debversion && \


### PR DESCRIPTION
I was seeing issues with different server (15) and client (17) versions of postgres. 15 was the latest available at the time when the image was built, but in https://github.com/gardenlinux/glvd-data-ingestion I'm using debian trixie which is now on postgres 17. This causes the following error when trying to restore the backups crated with client v 17 to a server v 15:

```
2025-01-13 13:37:11.779 UTC [56] ERROR:  unrecognized configuration parameter "transaction_timeout"
2025-01-13 13:37:11.779 UTC [56] STATEMENT:  SET transaction_timeout = 0;
psql:/docker-entrypoint-initdb.d/01-schema.sql:11: ERROR:  unrecognized configuration parameter "transaction_timeout"
make: *** [run] Error 3
```

Bumping all to 17 should resolve this for now.

The reason for using trixie in glvd-data-ingestion is that the ingestion python code needs a very new version of sql alchemy.

Fixes https://github.com/gardenlinux/glvd/issues/134