### PR TITLE
Make image more resilient

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,6 @@ ARG base=docker.io/library/postgres:17-bookworm
 FROM $base
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-17-debversion && \
-    echo 'CREATE EXTENSION debversion' > /docker-entrypoint-initdb.d/create-extension.sql
+    echo 'CREATE EXTENSION IF NOT EXISTS debversion WITH SCHEMA public;' > /docker-entrypoint-initdb.d/create-extension.sql
 
 ADD postgresql.conf /etc/postgresql/


### PR DESCRIPTION
Avoid 'psql:/docker-entrypoint-initdb.d/create-extension.sql:1: ERROR:  extension "debversion" already exists' error if restoring form dump file that also creates the extension
